### PR TITLE
fully automate installation of mysql-client@5.7 (unsupported)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - "14"
           - "15"
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "14"
+          - "15"
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -31,54 +31,6 @@ Optionally, review the log:
 less ~/laptop.log
 ```
 
-## MySQL 5.7 Hack
-
-`mysql-client@5.7` is now expired in homebrew, so we will need to install it manually.
-
-Tap homebrew-core
-
-```
-brew tap homebrew/core --force
-```
-
-Edit the `mysql-client@5.7` formula
-
-```
-brew edit mysql-client@5.7
-```
-
-Remove the line that begins with
-
-```
-disable! date:
-```
-
-Edit `openssl@1.1` formmula
-
-`openssl@1.1` is now unsupported, so we need to edit its installation file
-
-```
-brew edit openssl@1.1
-```
-
-Remove the following line
-
-```
-disable! date: "2024-10-24", because: :unsupported
-```
- 
-Install `mysql-client@5.7`
-
-```
-HOMEBREW_NO_INSTALL_FROM_API=1 brew install mysql-client@5.7
-```
-
-Link mysql binaries
-
-```
-brew link --force mysql-client@5.7
-```
-
 ## Debugging
 
 Your last laptop run will be saved to `~/laptop.log`. Read through it and see if

--- a/mac
+++ b/mac
@@ -153,7 +153,11 @@ function hack_unsupported_tap() {
 
   if [ -f "$formula" ]; then
     sed -i '' '/disable! date:/d' "$formula"
-    [[ $? -eq 0 ]] && echo "√ $1" || hack_unsupported_tap_failed "$1"
+    if [ $? -eq 0 ]; then 
+      echo "√ $1" 
+    else
+      hack_unsupported_tap_failed "$1" 
+    fi
   else
     hack_unsupported_tap_failed "$1"
   fi

--- a/mac
+++ b/mac
@@ -149,10 +149,15 @@ hack_unsupported_tap_failed() {
 hack_unsupported_tap() {
   # in the following command we might encounter .bak files that were not removed properly
   # so we ensure the actual Formula file is the one we select
-  local "formula"=$(find $HOMEBREW_PREFIX/Library/Taps -name "$1.*" | sort | head -1)
+  local formula="$(find $HOMEBREW_PREFIX/Library/Taps -name "$1.*" | sort | head -1)"
 
   if [ ! -f "$formula" ]; then
-    sed -i '' '/disable! date:/d' "$formula" && echo "√ $1" || hack_unsupported_tap_failed "$1" 
+    sed -i '' '/disable! date:/d' "$formula" 
+    if [ $? -ne 0 ]; then
+      hack_unsupported_tap_failed "$1" 
+    else
+      echo "√ $1" || 
+    fi
   else
     hack_unsupported_tap_failed "$1"
   fi

--- a/mac
+++ b/mac
@@ -151,12 +151,12 @@ hack_unsupported_tap() {
   # so we ensure the actual Formula file is the one we select
   local formula="$(find $HOMEBREW_PREFIX/Library/Taps -name "$1.*" | sort | head -1)"
 
-  if [ ! -f "$formula" ]; then
+  if [ -f "$formula" ]; then
     sed -i '' '/disable! date:/d' "$formula" 
-    if [ $? -ne 0 ]; then
-      hack_unsupported_tap_failed "$1" 
+    if [ $? -eq 0 ]; then
+      echo "√ $1"
     else
-      echo "√ $1" || 
+      hack_unsupported_tap_failed "$1" 
     fi
   else
     hack_unsupported_tap_failed "$1"

--- a/mac
+++ b/mac
@@ -131,6 +131,40 @@ brew "libpq", link: true
 # brew "mysql-client@5.7", link: true
 EOF
 
+# Hack Unsupported Taps
+# We still rely on a few brew packages that are now unsupported, and
+# need to hack their formulae to work.
+
+fancy_echo "Hacking unsupported brew Taps"
+
+brew tap homebrew/core --force
+
+function hack_unsupported_tap_failed() {
+  echo "WARNING: unable to correct $1 formula"
+  echo "Please use 'brew edit $1' to correct the formula"
+  echo "(remove the 'disable! date:' line)"
+  exit 1
+}
+
+function hack_unsupported_tap() {
+  # in the following command we might encounter .bak files that were not removed properly
+  # so we ensure the actual Formula file is the one we select
+  local formula=$(find $HOMEBREW_PREFIX/Library/Taps -name "$1.*" | sort | head -1)
+
+  if [ -f "$formula" ]; then
+    sed -i '' '/disable! date:/d' "$formula"
+    [[ $? -eq 0 ]] && echo "√ $1" || hack_unsupported_tap_failed "$1"
+  else
+    hack_unsupported_tap_failed "$1"
+  fi
+}
+
+hack_unsupported_tap openssl@1.1
+hack_unsupported_tap mysql-client@5.7
+
+unset -f hack_unsupported_tap
+unset -f hack_unsupported_tap_failed
+
 # Mac apps
 # This will first check if a user has either manually installed the app
 # or if homebrew has already installed the app so it doesn't get an error.

--- a/mac
+++ b/mac
@@ -135,7 +135,7 @@ EOF
 # We still rely on a few brew packages that are now unsupported, and
 # need to hack their formulae to work.
 
-fancy_echo "Hacking unsupported brew Taps"
+fancy_echo "Hacking unsupported brew Taps "
 
 brew tap homebrew/core --force
 

--- a/mac
+++ b/mac
@@ -149,7 +149,7 @@ hack_unsupported_tap_failed() {
 hack_unsupported_tap() {
   # in the following command we might encounter .bak files that were not removed properly
   # so we ensure the actual Formula file is the one we select
-  local formula="$(find $HOMEBREW_PREFIX/Library/Taps -name "$1.*" | sort | head -1)"
+  local formula ; formula="$(find $HOMEBREW_PREFIX/Library/Taps -name "$1.*" | sort | head -1)"
 
   if [ -f "$formula" ]; then
     sed -i '' '/disable! date:/d' "$formula" 

--- a/mac
+++ b/mac
@@ -165,6 +165,10 @@ hack_unsupported_tap mysql-client@5.7
 unset -f hack_unsupported_tap
 unset -f hack_unsupported_tap_failed
 
+# Install mysql-client@5.7
+HOMEBREW_NO_INSTALL_FROM_API=1 brew install mysql-client@5.7
+brew link --force mysql-client@5.7
+
 # Mac apps
 # This will first check if a user has either manually installed the app
 # or if homebrew has already installed the app so it doesn't get an error.

--- a/mac
+++ b/mac
@@ -149,7 +149,7 @@ hack_unsupported_tap_failed() {
 hack_unsupported_tap() {
   # in the following command we might encounter .bak files that were not removed properly
   # so we ensure the actual Formula file is the one we select
-  local formula=$(find $HOMEBREW_PREFIX/Library/Taps -name "$1.*" | sort | head -1)
+  local "formula"=$(find $HOMEBREW_PREFIX/Library/Taps -name "$1.*" | sort | head -1)
 
   if [ ! -f "$formula" ]; then
     sed -i '' '/disable! date:/d' "$formula" && echo "√ $1" || hack_unsupported_tap_failed "$1" 

--- a/mac
+++ b/mac
@@ -151,7 +151,7 @@ hack_unsupported_tap() {
   # so we ensure the actual Formula file is the one we select
   local formula=$(find $HOMEBREW_PREFIX/Library/Taps -name "$1.*" | sort | head -1)
 
-  if [ ! -f "$formula" ]
+  if [ ! -f "$formula" ]; then
     sed -i '' '/disable! date:/d' "$formula" && echo "√ $1" || hack_unsupported_tap_failed "$1" 
   else
     hack_unsupported_tap_failed "$1"

--- a/mac
+++ b/mac
@@ -152,8 +152,8 @@ hack_unsupported_tap() {
   local formula ; formula="$(find $HOMEBREW_PREFIX/Library/Taps -name "$1.*" | sort | head -1)"
 
   if [ -f "$formula" ]; then
-    sed -i '' '/disable! date:/d' "$formula" 
-    if [ $? -eq 0 ]; then
+    if sed -i '' '/disable! date:/d' "$formula" 
+    then
       echo "√ $1"
     else
       hack_unsupported_tap_failed "$1" 

--- a/mac
+++ b/mac
@@ -139,25 +139,20 @@ fancy_echo "Hacking unsupported brew Taps"
 
 brew tap homebrew/core --force
 
-function hack_unsupported_tap_failed() {
+hack_unsupported_tap_failed() {
   echo "WARNING: unable to correct $1 formula"
   echo "Please use 'brew edit $1' to correct the formula"
   echo "(remove the 'disable! date:' line)"
   exit 1
 }
 
-function hack_unsupported_tap() {
+hack_unsupported_tap() {
   # in the following command we might encounter .bak files that were not removed properly
   # so we ensure the actual Formula file is the one we select
   local formula=$(find $HOMEBREW_PREFIX/Library/Taps -name "$1.*" | sort | head -1)
 
-  if [ -f "$formula" ]; then
-    sed -i '' '/disable! date:/d' "$formula"
-    if [ $? -eq 0 ]; then 
-      echo "√ $1" 
-    else
-      hack_unsupported_tap_failed "$1" 
-    fi
+  if [ ! -f "$formula" ]
+    sed -i '' '/disable! date:/d' "$formula" && echo "√ $1" || hack_unsupported_tap_failed "$1" 
   else
     hack_unsupported_tap_failed "$1"
   fi


### PR DESCRIPTION
# Description

This script now automatically hacks known unsupported Homebrew Taps to allow automated installation of the `mysql-client@5.7`.

## Issues Resolved

- remove `disable! date:` from `openssl@1.1` formula
- remove `disable! date:` from `mysql-client@5.7` formula
- complete the install of `mysql-client@5.7`