### PR TITLE
adding jq to the regular installation

### DIFF
--- a/mac
+++ b/mac
@@ -123,6 +123,7 @@ brew "libyaml" # should come after openssl
 brew "readline"
 brew "yarn"
 brew "zlib"
+brew "jq"
 
 # Databases
 brew "libpq", link: true


### PR DESCRIPTION
# Description

adding `jq` to our regular developer install

## Issues Resolved

- included `jq` in the Homebrew setup

