### PR TITLE
TBDEV-4626 Add Ruby 2.7.8 and RubyGems 3.2.3 to laptop script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,3 +75,15 @@ jobs:
 
       - name: Run mac setup script
         run: sh mac
+
+      - name: Verify Ruby 2.6.7 is installed with RubyGems 3.2.3
+        run: |
+          export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
+          ASDF_RUBY_VERSION=2.6.7 ruby --version | grep "2.6.7"
+          ASDF_RUBY_VERSION=2.6.7 gem --version | grep "3.2.3"
+
+      - name: Verify Ruby 2.7.8 is global with RubyGems 3.2.3
+        run: |
+          export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
+          ruby --version | grep "2.7.8"
+          gem --version | grep "3.2.3"

--- a/mac
+++ b/mac
@@ -535,13 +535,15 @@ export CFLAGS=-Wno-error="implicit-function-declaration"
 
 install_asdf_plugin "ruby" "https://github.com/asdf-vm/asdf-ruby.git"
 install_asdf_language "ruby" "2.6.7"
+install_asdf_language "ruby" "2.7.8"
+run_cmd "setting default ruby version to 2.7.8" asdf set -u ruby 2.7.8
 
 # --- Reinstall previously installed Ruby versions (from asdf upgrade) ---
 if [ ${#reinstall_rubies[@]} -gt 0 ]; then
   log "Reinstalling previously installed Ruby versions ..."
   for ruby_version in "${reinstall_rubies[@]}"; do
     # Skip 2.6.7 since we just installed it
-    if [ "$ruby_version" != "2.6.7" ]; then
+    if [ "$ruby_version" != "2.6.7" ] && [ "$ruby_version" != "2.7.8" ]; then
       if ! asdf list ruby | grep -q "$ruby_version"; then
         run_cmd "reinstalling ruby $ruby_version" asdf install ruby "$ruby_version"
       else
@@ -554,20 +556,40 @@ fi
 
 # --- Check Ruby OpenSSL compatibility ---
 log "Checking Ruby OpenSSL compatibility ..."
-if ! ruby -ropenssl -e "" 2>/dev/null; then
-  log_warning "Ruby's OpenSSL extension cannot load (likely compiled against old openssl@1.1)"
-  log_warning "Reinstalling Ruby 2.6.7..."
-  asdf uninstall ruby 2.6.7
-  run_cmd "reinstalling ruby 2.6.7" asdf install ruby 2.6.7
-  run_cmd "setting default ruby version to 2.6.7" asdf set -u ruby 2.6.7
 
-  # Verify fix worked
+# Check Ruby 2.7.8 (global)
+if ! ruby -ropenssl -e "" 2>/dev/null; then
+  log_warning "Ruby 2.7.8 OpenSSL extension cannot load (likely compiled against old openssl@1.1)"
+  log_warning "Reinstalling Ruby 2.7.8..."
+  asdf uninstall ruby 2.7.8
+  run_cmd "reinstalling ruby 2.7.8" asdf install ruby 2.7.8
+  run_cmd "setting default ruby version to 2.7.8" asdf set -u ruby 2.7.8
+
   if ! ruby -ropenssl -e "" 2>/dev/null; then
-    log_error "Ruby OpenSSL extension still cannot load after reinstall"
+    log_error "Ruby 2.7.8 OpenSSL extension still cannot load after reinstall"
     exit 1
   fi
 fi
-log_success "Ruby OpenSSL extension is working"
+log_success "Ruby 2.7.8 OpenSSL extension is working"
+
+# Check Ruby 2.6.7
+if ! ASDF_RUBY_VERSION=2.6.7 ruby -ropenssl -e "" 2>/dev/null; then
+  log_warning "Ruby 2.6.7 OpenSSL extension cannot load (likely compiled against old openssl@1.1)"
+  log_warning "Reinstalling Ruby 2.6.7..."
+  asdf uninstall ruby 2.6.7
+  run_cmd "reinstalling ruby 2.6.7" asdf install ruby 2.6.7
+
+  if ! ASDF_RUBY_VERSION=2.6.7 ruby -ropenssl -e "" 2>/dev/null; then
+    log_error "Ruby 2.6.7 OpenSSL extension still cannot load after reinstall"
+    exit 1
+  fi
+fi
+log_success "Ruby 2.6.7 OpenSSL extension is working"
+
+log "Installing RubyGems 3.2.3 ..."
+run_cmd "updating rubygems to 3.2.3 for ruby 2.7.8" gem update --system 3.2.3
+run_cmd "updating rubygems to 3.2.3 for ruby 2.6.7" ASDF_RUBY_VERSION=2.6.7 gem update --system 3.2.3
+log_success "RubyGems 3.2.3 installed on both Ruby versions"
 
 log "Optimizing bundler ..."
 if [ ! -f "$HOME/bundle/config" ]; then

--- a/mac
+++ b/mac
@@ -588,7 +588,7 @@ log_success "Ruby 2.6.7 OpenSSL extension is working"
 
 log "Installing RubyGems 3.2.3 ..."
 run_cmd "updating rubygems to 3.2.3 for ruby 2.7.8" gem update --system 3.2.3
-run_cmd "updating rubygems to 3.2.3 for ruby 2.6.7" ASDF_RUBY_VERSION=2.6.7 gem update --system 3.2.3
+run_cmd "updating rubygems to 3.2.3 for ruby 2.6.7" env ASDF_RUBY_VERSION=2.6.7 gem update --system 3.2.3
 log_success "RubyGems 3.2.3 installed on both Ruby versions"
 
 log "Optimizing bundler ..."


### PR DESCRIPTION
## Summary

- Install Ruby 2.7.8 via asdf and set it as the new global Ruby version (alongside existing 2.6.7)
- Pin RubyGems 3.2.3 on both Ruby 2.6.7 and 2.7.8
- Update OpenSSL compatibility checks to verify both Ruby versions independently
- Add CI verification steps confirming correct Ruby and RubyGems versions

## Test plan

- [x] CI lint jobs pass on macos-15 and macos-26
- [x] CI test jobs pass on macos-15 and macos-26
- [x] New verification steps confirm `ruby --version` returns 2.7.8 (global) and `gem --version` returns 3.2.3 on both Rubies

## QA plan

1. Run the laptop script:
   ```bash
   sh mac
   ```

2. Verify both Ruby versions are installed:
   ```bash
   asdf list ruby
   ```
   Expected output should include `2.6.7` and `2.7.8`.

3. Verify Ruby 2.7.8 is set as the global default:
   ```bash
   asdf current ruby
   ```
   Expected: `ruby  2.7.8` resolved from `~/.tool-versions`

4. Verify RubyGems 3.2.3 on Ruby 2.7.8 (global):
   ```bash
   ASDF_RUBY_VERSION=2.7.8 gem --version
   ```
   Expected: `3.2.3`

5. Verify RubyGems 3.2.3 on Ruby 2.6.7:
   ```bash
   ASDF_RUBY_VERSION=2.6.7 gem --version
   ```
   Expected: `3.2.3`

6. Run the script a second time to confirm idempotency (no errors on re-run):
   ```bash
   sh mac
   ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)